### PR TITLE
Fix floating point comparison precision expansion error in test case.

### DIFF
--- a/src/Tests/Tests/Test_Tools.cpp
+++ b/src/Tests/Tests/Test_Tools.cpp
@@ -406,7 +406,7 @@ TEST_CASE("ToolsGammatone", "[ToolsGammatone]")
         for (auto c = 0; c < iNumBands; c++)
             CHECK(0.F == CVector::getSum(ppfOut[c], iLenBuff, true));
 
-        CHECK(fStartFreq == pCGammatone->getCenterFreq(0));
+        CHECK_THAT(fStartFreq, Catch::Matchers::WithinAbs(pCGammatone->getCenterFreq(0), 0.00001f));
 
         CHECK(Error_t::kNoError == CGammaToneFbIf::destroy(pCGammatone));
     }


### PR DESCRIPTION
When running the test, the TestTool failed with the message: "Fails with expansion: 100.0f == 100.00001"

I imagine this is some combination of my stack. The proposed fixed (which I think is preferrable, especially if the float isn't known to be created in the same way), is to compare the two floats to with a precision threshold. I chose the precision to be the same as that that was in the error message, but I am not sure if there is a more appropriate number.